### PR TITLE
Fix webpage layout issues

### DIFF
--- a/docs/assets/css/styles.css
+++ b/docs/assets/css/styles.css
@@ -12,7 +12,9 @@ body {
 }
 
 .wrapper {
-  max-width: calc(940px - (30px * 2));
+  max-width: calc(1200px - (30px * 2));
+  margin-right: auto;
+  margin-left: auto;
 }
 
 h1 {
@@ -192,6 +194,16 @@ pre {
 .sys-img {
   width: 90%;
   margin-left: 5%;
+  max-width: 800px;
+  margin: 0 auto;
+  display: block;
+}
+
+.sys-img img {
+  width: 100%;
+  height: auto;
+  object-fit: contain;
+  max-height: 500px;
 }
 
 
@@ -331,6 +343,11 @@ strong {
   .sys-img {
     width: 100%;
     margin-left: 0;
+    max-width: 100%;
+  }
+  
+  .sys-img img {
+    max-height: 400px;
   }
 
   .acknowledgement {


### PR DESCRIPTION
This PR addresses two layout issues in the webpage:

1. Makes images in the main section have consistent sizes while maintaining aspect ratios
- Added max-width and max-height constraints
- Used object-fit: contain for proper scaling
- Adjusted mobile view settings

2. Increases the overall width of the homepage
- Increased max-width from 940px to 1200px
- Added proper centering with auto margins

These changes improve the visual consistency and make better use of available screen space.