### PR TITLE
Fix system image width to match text content

### DIFF
--- a/docs/assets/css/styles.css
+++ b/docs/assets/css/styles.css
@@ -200,18 +200,17 @@ pre {
 .sys-img {
   text-align: center;
   margin: 30px auto;
-  width: 70%;
-  height: 400px;
+  width: 100%;
+  max-width: 1000px;
+  height: auto;
   display: flex;
   justify-content: center;
   align-items: center;
 }
 
 .sys-img img {
-  width: auto;
+  width: 100%;
   height: auto;
-  max-width: 100%;
-  max-height: 100%;
   object-fit: contain;
 }
 


### PR DESCRIPTION
This PR fixes the system image width issue by:

- Making images take full container width
- Setting a max-width to prevent oversized images
- Maintaining aspect ratio
- Ensuring proper scaling on different screen sizes

The changes make system images match the width of the text content while maintaining proper proportions.